### PR TITLE
Wire up Circle CI for unit and integration tests

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,15 @@
+---
+driver:
+  name: rackspace
+  flavor_id: performance1-2
+  image_id: 09de0a66-3156-48b4-90a5-1cf25a905207
+  public_key_path: ~/.ssh/id_chef-solo-github.pub
+  rackspace_username: <%= ENV['RACKSPACE_USERNAME'] %>
+  rackspace_api_key: <%= ENV['RACKSPACE_API_KEY'] %>
+  rackspace_region: IAD
+  require_chef_omnibus: latest
+  server_name: ci-<%= ENV['CIRCLE_PROJECT_REPONAME'] %>-<%= ENV['CIRCLE_BUILD_NUM'] %>
+  wait_for: 1200
+platforms:
+   - name: default-ubuntu-1404
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ cache: bundler
 sudo: false
 rvm:
   - 2.0.0
-script: bundle exec rake travis:ci
+script: bundle exec rake style

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,32 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 source 'https://rubygems.org'
 
 group :style do
   gem 'foodcritic'
   gem 'rubocop'
-  gem 'rubocop-rspec'
 end
 
-group :unit do
-  gem 'berkshelf', '~> 3'
-  gem 'chefspec', '~> 4'
-  gem 'chef-sugar'
+group :spec do
+  gem 'berkshelf'
+  gem 'chefspec'
 end
 
 group :integration do
   gem 'test-kitchen', '~> 1.4.0'
+end
+
+group :integration_vagrant do
   gem 'kitchen-vagrant'
+  gem 'vagrant-wrapper'
+end
+
+group :integration_rackspace do
+  gem 'kitchen-rackspace'
+end
+
+group :development do
+  gem 'thor-scmversion'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,42 +1,68 @@
 # encoding: UTF-8
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+# Based on magic_shell cookbook code, thanks @sethvargo.
 
 require 'bundler/setup'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+require 'foodcritic'
+require 'kitchen'
 
 namespace :style do
-  require 'rubocop/rake_task'
-  desc 'Run Ruby style checks'
+  desc 'Ruby style checks'
   RuboCop::RakeTask.new(:ruby)
 
-  require 'foodcritic'
-  desc 'Run Chef style checks'
+  desc 'Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef)
 end
 
-desc 'Run all style checks'
-task style: %w(style:chef style:ruby)
-
-task :unit do
-  sh "bundle exec 'rspec ./test/unit/spec/ --color --format documentation'"
+# Rspec and ChefSpec
+desc 'Run ChefSpec unit tests'
+RSpec::Core::RakeTask.new(:spec) do |t, _args|
+  t.rspec_opts = 'test/unit'
 end
 
-desc 'Run Test Kitchen integration tests'
-task :integration do
-  require 'kitchen'
-  Kitchen.logger = Kitchen.default_file_logger
-  Kitchen::Config.new.instances.each do |instance|
-    instance.test(:always)
+# Integration tests. Kitchen.ci
+namespace :integration do
+  desc 'Test Kitchen with Vagrant'
+  task :vagrant do
+    Kitchen.logger = Kitchen.default_file_logger
+    Kitchen::Config.new.instances.each do |instance|
+      instance.test(:always)
+    end
+  end
+
+  desc 'Test Kitchen with cloud plugins'
+  task :cloud do
+    if ENV['CI'] == 'true'
+      Kitchen.logger = Kitchen.default_file_logger
+      @loader = Kitchen::Loader::YAML.new(local_config: '.kitchen.cloud.yml')
+      config = Kitchen::Config.new(loader: @loader)
+      concurrency = config.instances.size
+      queue = Queue.new
+      config.instances.each { |i| queue << i }
+      concurrency.times { queue << nil }
+      threads = []
+      concurrency.times do
+        threads << Thread.new do
+          while (instance = queue.pop)
+            instance.test(:always)
+          end
+        end
+      end
+      threads.map(&:join)
+    end
   end
 end
 
-desc 'Run all tests'
-task test: %w(style unit integration)
+desc 'All style checks'
+task style: %w(style:chef style:ruby)
 
-desc 'Tasks to run on Travis CI'
-namespace :travis do
-  desc 'Run tests on Travis'
-  task ci: %w(style)
-end
+desc 'All tests'
+task test: %w(style spec integration:vagrant)
 
-task default: %w(style unit integration)
+desc 'CI tests'
+task ci: %w(style spec integration:cloud)
+
+task default: %w(test)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  ruby:
+    version: 2.1.5
+  environment:
+    KITCHEN_LOCAL_YAML: .kitchen.cloud.yml
+
+dependencies:
+  cache_directories:
+    - "~/bundle"
+  override:
+    - bundle install --path=~/bundle --without=development --jobs=4 --retry=3:
+        timeout: 1000
+
+test:
+  override:
+    - bundle exec rake style:
+        timeout: 120
+    - bundle exec rake spec:
+        timeout: 120
+    - bundle exec rake integration:cloud:
+        timeout: 1000

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,6 +58,7 @@ end
 
 metrics_credentials = Chef::EncryptedDataBagItem.load('blueflood', "repose_#{node.env}")
 
+identity_url = node['repose']['keystone_v2']['identity_uri'] || ''
 identity_url = URI.join(identity_url, '/').to_s # strip trailing path (repose adds it)
 
 node.set['repose']['keystone_v2']['identity_uri'] = identity_url

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 require_relative 'spec_helper'
 
-describe 'ele-repose::default' do
+describe 'metrics-repose::default' do
   before { stub_resources }
 
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -7,7 +7,7 @@ describe 'metrics-repose::default' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'includes the `repose` recipe' do
-    expect(chef_run).to include_recipe('repose::default')
+    expect(chef_run).to include_recipe('repose::install')
   end
 
   it 'includes the `java` recipe' do

--- a/test/unit/spec/filter-keystone-v2.rb
+++ b/test/unit/spec/filter-keystone-v2.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 require_relative 'spec_helper'
 
-describe 'ele-repose::filter-keystone-v2' do
+describe 'metrics-repose::filter-keystone-v2' do
   before { stub_resources }
 
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }

--- a/test/unit/spec/filter-merge-header.rb
+++ b/test/unit/spec/filter-merge-header.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 require_relative 'spec_helper'
 
-describe 'ele-repose::filter-merge-header' do
+describe 'metrics-repose::filter-merge-header' do
   before { stub_resources }
 
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }

--- a/test/unit/spec/filter-valkyrie-authorization.rb
+++ b/test/unit/spec/filter-valkyrie-authorization.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 require_relative 'spec_helper'
 
-describe 'ele-repose::filter-valkyrie-authorization' do
+describe 'metrics-repose::filter-valkyrie-authorization' do
   before { stub_resources }
 
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }


### PR DESCRIPTION
This brings `metrics-repose` in line with the [foobar](https://github.com/mmi-cookbooks/foobar-chef) template I've been using, while keeping the version constraints as-is.

In addition to Travis (for now?), this makes Circle CI run {style, unit and integration} tests using Cloud Monitoring's test account. :smile: 