### PR TITLE
Update global limit and http-connection-pool 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2
+- Update global limit for rate-limiting filter
+- Fix incorrect attribute names for http_connection_pool and update values 
+
 # 0.1.1
 - Update the logging format to add in additional HTTP headers
 - Include install recipe in query and ingest setup so that on initial installs, chef doesn't bail when /etc/repose isn't extant

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,10 +28,10 @@ default['repose']['services'] = %w(
 )
 
 default['repose']['http_connection_pool']['chunked_encoding'] = false
-default['repose']['connection_pool']['socket_timeout'] = 600_000 # in millis
-default['repose']['connection_pool']['connection_timeout'] = 30_000 # in millis
-default['repose']['connection_pool']['max_total'] = 1000
-default['repose']['connection_pool']['max_per_route'] = 500
+default['repose']['http_connection_pool']['socket_timeout'] = 600_000 # in millis
+default['repose']['http_connection_pool']['connection_timeout'] = 30_000 # in millis
+default['repose']['http_connection_pool']['max_total'] = 16000
+default['repose']['http_connection_pool']['max_per_route'] = 16000
 
 default['repose']['header_normalization']['cluster_id'] = ['all']
 default['repose']['header_normalization']['uri_regex'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.1'
+version '0.1.2'
 
 depends 'apt'
 depends 'java'

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -93,7 +93,7 @@ node.default['repose']['rate_limiting']['global_limits'] = [
     'id' => 'global',
     'uri' => '*',
     'uri-regex' => '.*',
-    'value' => 1000,
+    'value' => 10_000,
     'http-methods' => 'ALL',
     'unit' => 'MINUTE'
   }


### PR DESCRIPTION
# What
Bump version to 0.1.2.  Update the global-limit setting for query nodes to 10000 (from 1000).  Update the http_connection_pool setting to 16000 max total connection. 

# How
Update recipe and attributes files.

# How to test 
Deploy and confirm that repose is behaving normally (based on grafana and logs).