### PR TITLE
Add overlimit-429-responsecode attribute

### DIFF
--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -79,6 +79,7 @@ node.default['repose']['rate_limiting']['cluster_id'] = ['all']
 node.default['repose']['rate_limiting']['uri_regex'] = '/v[0-9.]+/(hybrid:)?[0-9]+/limits/?'
 node.default['repose']['rate_limiting']['include_absolute_limits'] = true
 node.default['repose']['rate_limiting']['use_capture_groups'] = false
+node.default['repose']['rate_limiting']['overlimit_429_responsecode'] = true
 node.default['repose']['rate_limiting']['global_limits'] = [
   {
     'id' => 'global',

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -86,6 +86,7 @@ node.default['repose']['rate_limiting']['cluster_id'] = ['all']
 node.default['repose']['rate_limiting']['uri_regex'] = '/v[0-9.]+/(hybrid:)?[0-9]+/limits/?'
 node.default['repose']['rate_limiting']['include_absolute_limits'] = true
 node.default['repose']['rate_limiting']['use_capture_groups'] = false
+node.default['repose']['rate_limiting']['overlimit_429_responsecode'] = true
 node.default['repose']['rate_limiting']['global_limits'] = [
   {
     'id' => 'global',


### PR DESCRIPTION
# What
This will set the overLimit-429-responsecode attribute in our rate-limiting.cfg.xml. By default repose returns 413 response codes on rate-limited requests.