### PR TITLE
Update log rotation settings for repose blueflood logs, bump to 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.7
+- Update default number of log files to keep for /var/log/repose/blueflood-<instance>.log, downsize to 6 so we don't cause disk space alerts
+
 # 0.1.6
 - Update upstart script to refer to default-java instead of specific version
 - Update customer rate-limit defaults to 2000/MIN for ingest and query (was ingest 1000/MIN and query 1500/MIN)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.6'
+version '0.1.7'
 
 depends 'apt'
 depends 'java'

--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -31,7 +31,7 @@ node.default['repose']['appenders'] = ['<RollingFile name="blueflood-ingest" fil
             <Policies>
                 <SizeBasedTriggeringPolicy size="1024 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="20"/>
+            <DefaultRolloverStrategy max="6"/>
         </RollingFile>']
 node.default['repose']['loggers'] = ['<Logger name="ingest-repose-http-log" level="info">
             <AppenderRef ref="blueflood-ingest"/>

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -31,7 +31,7 @@ node.default['repose']['appenders'] = ['<RollingFile name="blueflood-query" file
             <Policies>
                 <SizeBasedTriggeringPolicy size="1024 MB"/>
             </Policies>
-            <DefaultRolloverStrategy max="20"/>
+            <DefaultRolloverStrategy max="6"/>
         </RollingFile>']
 node.default['repose']['loggers'] = ['<Logger name="query-repose-http-log" level="info">
             <AppenderRef ref="blueflood-query"/>


### PR DESCRIPTION
## What
Update number of files saved on disk from 20 to 6.  We have too many on disk and hitting alert thresholds.