### PR TITLE
adding tenanted-url authentication for keystone-v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.8
+- Adding tenanted-url to the keystone-v2 filter
+
 # 0.1.7
 - Update default number of log files to keep for /var/log/repose/blueflood-<instance>.log, downsize to 6 so we don't cause disk space alerts
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,3 +66,9 @@ default['repose']['ip_identity']['cluster_id'] = ['all']
 default['repose']['ip_identity']['quality'] = 0.2
 default['repose']['ip_identity']['white_list_quality'] = 1.0
 default['repose']['ip_identity']['white_list_ip_addresses'] = ['127.0.0.1', '69.20.62.248/29', '10.190.252.12/32', '10.190.252.10/32']
+
+default['repose']['keystone_v2']['tenant_handling'] = {
+  'validate_tenant' => {
+    'url_extraction_regex' => '/v2.0/([^/]+)/.+'
+  }
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.7'
+version '0.1.8'
 
 depends 'apt'
 depends 'java'

--- a/test/unit/spec/filter-keystone-v2.rb
+++ b/test/unit/spec/filter-keystone-v2.rb
@@ -6,3 +6,34 @@ describe 'metrics-repose::filter-keystone-v2' do
 
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 end
+
+describe 'repose::filter-keystone-v2' do
+  before { stub_resources }
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set['repose']['version']                                    = '7.2.0.0'
+      node.set['repose']['filters']                                    = ['keystone-v2']
+    end.converge(described_recipe)
+  end
+
+  it 'keystone-v2 has correct namespace for version 7' do
+    expect(chef_run).to render_file('/etc/repose/keystone-v2.cfg.xml').with_content(%r{<keystone-v2 xmlns="http:\/\/docs.openrepose.org\/repose\/keystone-v2\/v1.0">})
+  end
+
+  it 'keystone-v2 has correct username' do
+    expect(chef_run).to render_file('/etc/repose/keystone-v2.cfg.xml').with_content(/<identity-service\s+username="admin"/)
+  end
+
+  it 'keystone-v2 has correct password' do
+    expect(chef_run).to render_file('/etc/repose/keystone-v2.cfg.xml').with_content(/<identity-service[^<]+password="password"/)
+  end
+
+  it 'keystone-v2 has correct uri' do
+    expect(chef_run).to render_file('/etc/repose/keystone-v2.cfg.xml').with_content(/<identity-service[^<]+uri="https:\/\/identity.api.rackspacecloud.com\/v2.0"\/)
+  end
+
+  it 'keystone-v2 has correct tenant-handling' do
+    expect(chef_run).to render_file('/etc/repose/keystone-v2.cfg.xml').with_content(/<tenant-handling >[^<]+<validate-tenant>[^<]+<uri-extraction-regex>\/v2.0\/\(\[\^/\]\+\)\/\.\+<\/uri-extraction-regex>/)
+  end
+end


### PR DESCRIPTION
Adding following XML to keystone-v2 configuration

```
  <tenant-handling>
    <validate-tenant>
      <uri-extraction-regex>/v2.0/([^/]+)/.+</uri-extraction-regex>
    </validate-tenant>
  #</tenant-handling>
```

This has the potential to break our current customers.  All customers will need to ensure that they have their tenant id in all requested URLs.

I plan to have this change in staging for a week, and send out a communication to our users, and then push to prod at the end of the week.  
