### PR TITLE
configure rate limit values

### DIFF
--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -85,7 +85,7 @@ node.default['repose']['rate_limiting']['global_limits'] = [
     'id' => 'global',
     'uri' => '*',
     'uri-regex' => '.*',
-    'value' => 100_000,
+    'value' => 3000,
     'http-methods' => 'ALL',
     'unit' => 'MINUTE'
   }
@@ -102,7 +102,7 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
         'uri_regex' => '/v[0-9.]+/((hybrid:)?[0-9]+)/.+',
         'http_methods' => 'ALL',
         'unit' => 'MINUTE',
-        'value' => 2000
+        'value' => 3000
       }
     ]
   },
@@ -114,10 +114,10 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
       {
         'id' => 'near-unlimited',
         'uri' => '/version/tenantId/*',
-        'uri_regex' => '/v[0-9.]+/((hybrid:)?[0-9]+)/.+',
+        'uri_regex' => '/v[0-9.]+/706456/.+',
         'http_methods' => 'ALL',
         'unit' => 'MINUTE',
-        'value' => 100_000
+        'value' => 20_000
       }
     ]
   }

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -92,7 +92,7 @@ node.default['repose']['rate_limiting']['global_limits'] = [
     'id' => 'global',
     'uri' => '*',
     'uri-regex' => '.*',
-    'value' => 10_000,
+    'value' => 1000,
     'http-methods' => 'ALL',
     'unit' => 'MINUTE'
   }
@@ -107,6 +107,21 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
         'id' => 'version-tenantId',
         'uri' => '/version/tenantId/*',
         'uri_regex' => '/v[0-9.]+/((hybrid:)?[0-9]+)/.+',
+        'http_methods' => 'ALL',
+        'unit' => 'MINUTE',
+        'value' => 1000
+      }
+    ]
+  },
+  {
+    'id' => 'lbaas-prod',
+    'groups' => 'IP_Super',
+    'default' => false,
+    'limits' => [
+      {
+        'id' => 'near-unlimited',
+        'uri' => '/version/tenantId/*',
+        'uri_regex' => '/v[0-9.]+/959877/.+',
         'http_methods' => 'ALL',
         'unit' => 'MINUTE',
         'value' => 2000


### PR DESCRIPTION
# What
Configure rate limit values in repose for default ingest and query nodes, and set special rules for
- ingest from maas-prod
- query from lbaas-prod

# Why

Base on analysis of last 30 days, set more realistic rate limit values that will actually do some good to prevent DOS and DDOS scenarios.

# How

Modify the recipes/ingest.rb and recipes/query.rb files to have the desired values for "node.default['repose']['rate_limiting']['global_limits'] " and "node.default['repose']['rate_limiting']['limit_groups'] ".

# Test

To verify after deployment, ssh to the appropriate ingest and query nodes and verify the file 
/etc/repose/rate-limiting.cfg.xml

Content should match those presented in this wiki (bottom of page):  https://one.rackspace.com/display/cloudmetrics/Rate+Limiting
