### PR TITLE
add the add-header filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.13
+- Add the add-header filter to inject Content-Type header if it's not present
+
 # 0.1.12
 - Tweak rate limit values in repose for ingest and query nodes.
 - Set special ingest rate limit for maas-prod tenant, and special query rate limit for lbaas-prod tenant.

--- a/README.md
+++ b/README.md
@@ -62,5 +62,13 @@ To release a new version of this cookbook, do the following:
 
 Then you probably want to update some Berksfiles :smile:
 
+## Building and Testing
+
+### Requirements
+1. Vagrant
+Download it from: https://www.vagrantup.com/downloads.html
+2. Virtual Box
+Download it from: https://www.virtualbox.org/wiki/Downloads
+
 ## Kitchen and Travis
 You can run 'kitchen test' or 'kitchen converge [ingest|query]' to test the cookbook.  This cookbook will run some lint checking on TravisCI when pushed to github.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,17 +62,17 @@ default['repose']['header_normalization']['blacklist'] = [{
 }]
 
 default['repose']['add_header']['requests'] = [{
-    name:      'content-type',
-    quality:   '1',
-    overwrite: 'false',
-    value:     'application/json'
+  name:      'content-type',
+  quality:   '1',
+  overwrite: 'false',
+  value:     'application/json'
 }]
 
 default['repose']['add_header']['responses'] = [{
-    name:      'content-type',
-    quality:   '1',
-    overwrite: 'false',
-    value:     'application/json'
+  name:      'content-type',
+  quality:   '1',
+  overwrite: 'false',
+  value:     'application/json'
 }]
 
 default['repose']['ip_user']['cluster_id'] = ['all']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@ default['repose']['slf4j_http_logging']['format'] = '<![CDATA[
 default['repose']['filters'] = %w(
   slf4j-http-logging
   header-normalization
+  add-header
   keystone-v2
   ip-identity
   rate-limiting
@@ -58,6 +59,20 @@ default['repose']['header_normalization']['blacklist'] = [{
     X-Subject-Name
     X-Subject-ID
   )
+}]
+
+default['repose']['add_header']['requests'] = [{
+    name:      'content-type',
+    quality:   '1',
+    overwrite: 'false',
+    value:     'application/json'
+}]
+
+default['repose']['add_header']['responses'] = [{
+    name:      'content-type',
+    quality:   '1',
+    overwrite: 'false',
+    value:     'application/json'
 }]
 
 default['repose']['ip_user']['cluster_id'] = ['all']

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.12'
+version '0.1.13'
 
 depends 'apt'
 depends 'java'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,6 +65,7 @@ node.default['repose']['endpoints'] = [{
 # NOTE these hash keys should be left as strings or system-model.cfg.xml.erb will break
 filter_cluster_map = {
   'header-normalization'   => node['repose']['header_normalization']['cluster_id'],
+  'add-header'             => node['repose']['add_header']['cluster_id'],
   'slf4j-http-logging'     => node['repose']['slf4j_http_logging']['cluster_id'],
   'keystone-v2'            => node['repose']['keystone_v2']['cluster_id'],
   'ip-identity'            => node['repose']['ip_identity']['cluster_id'],
@@ -74,6 +75,7 @@ filter_cluster_map = {
 
 filter_uri_regex_map = {
   'header-normalization'   => node['repose']['header_normalization']['uri_regex'],
+  'add-header'             => node['repose']['add_header']['uri_regex'],
   'slf4j-http-logging'     => node['repose']['slf4j_http_logging']['uri_regex'],
   'keystone-v2'            => node['repose']['keystone_v2']['uri_regex'],
   'ip-identity'            => node['repose']['ip_identity']['uri_regex'],


### PR DESCRIPTION
This is to solve use case that some existing clients do not send Content-Type header. We put this add-header to insert Content-Type: application/json, so our Blueflood app don't have to check for empty Content-Type.