### PR TITLE
fix rate limit values for global, ingest, and query nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.14
+- Fix rate limit values set incorrectly in 0.1.12
+
 # 0.1.13
 - Add the add-header filter to inject Content-Type header if it's not present
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.13'
+version '0.1.14'
 
 depends 'apt'
 depends 'java'

--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -85,7 +85,7 @@ node.default['repose']['rate_limiting']['global_limits'] = [
     'id' => 'global',
     'uri' => '*',
     'uri-regex' => '.*',
-    'value' => 3000,
+    'value' => 100_000,
     'http-methods' => 'ALL',
     'unit' => 'MINUTE'
   }
@@ -102,7 +102,7 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
         'uri_regex' => '/v[0-9.]+/((hybrid:)?[0-9]+)/.+',
         'http_methods' => 'ALL',
         'unit' => 'MINUTE',
-        'value' => 3000
+        'value' => 5000
       }
     ]
   },
@@ -114,10 +114,10 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
       {
         'id' => 'near-unlimited',
         'uri' => '/version/tenantId/*',
-        'uri_regex' => '/v[0-9.]+/706456/.+',
+        'uri_regex' => '/v[0-9.]+/((hybrid:)?[0-9]+)/.+',
         'http_methods' => 'ALL',
         'unit' => 'MINUTE',
-        'value' => 20_000
+        'value' => 100_000
       }
     ]
   }

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -92,7 +92,7 @@ node.default['repose']['rate_limiting']['global_limits'] = [
     'id' => 'global',
     'uri' => '*',
     'uri-regex' => '.*',
-    'value' => 1000,
+    'value' => 10_000,
     'http-methods' => 'ALL',
     'unit' => 'MINUTE'
   }
@@ -107,21 +107,6 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
         'id' => 'version-tenantId',
         'uri' => '/version/tenantId/*',
         'uri_regex' => '/v[0-9.]+/((hybrid:)?[0-9]+)/.+',
-        'http_methods' => 'ALL',
-        'unit' => 'MINUTE',
-        'value' => 1000
-      }
-    ]
-  },
-  {
-    'id' => 'lbaas-prod',
-    'groups' => 'IP_Super',
-    'default' => false,
-    'limits' => [
-      {
-        'id' => 'near-unlimited',
-        'uri' => '/version/tenantId/*',
-        'uri_regex' => '/v[0-9.]+/959877/.+',
         'http_methods' => 'ALL',
         'unit' => 'MINUTE',
         'value' => 2000


### PR DESCRIPTION
# What

- Revert global rate limit to old values (100_000 for ingest, 10_000 for query)
- bump IP_Standard limit-groups to 5000 per minute per tenant.

# Why
- Small global values were causing 503s to be returned (repose global rate limiting always return 503s).
- we're nearing the 2000 per minute mark for IP_Standard tenant.