### PR TITLE
Add basic unit tests for the metrics-repose cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ brew cask install virtualbox
 brew cask install vagrant
 ```
 
-## Kitchen and Travis
+### Unit tests
+These can be run using the command $ chef exec rspec test/unit  
+or with the Rake task $ rake unit
+
+Unit tests will automatically be run in TravisCI on PRs and branch uploads.
+
+### Kitchen and Travis
 You can run 'kitchen test' or 'kitchen converge [ingest|query]' to test the cookbook.  This cookbook will run some lint checking on TravisCI when pushed to github.
 
 ```

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,12 +22,6 @@ link '/etc/init.d/repose-valve' do
   to '/lib/init/upstart-job'
 end
 
-service 'repose-valve' do
-  supports restart: true, status: true
-  action [:enable, :start]
-  provider Chef::Provider::Service::Upstart
-end
-
 template '/etc/repose/metrics.cfg.xml' do
   source 'metrics.cfg.xml.erb'
   owner 'root'
@@ -38,12 +32,6 @@ end
 unless node['repose']['cluster_id'].nil?
   log "Please note that node['repose']['cluster_id'] is deprecated. We've set node['repose']['cluster_ids'] to [#{node['repose']['cluster_id']}] in an effort to maintain compatibility with earlier versions. This functionality will be removed in a future version."
   node.normal['repose']['cluster_ids'] = [node['repose']['cluster_id']]
-end
-
-directory node['repose']['config_directory'] do
-  owner node['repose']['owner']
-  group node['repose']['group']
-  mode '0755'
 end
 
 services = node['repose']['services'].reject { |x| x == 'http-connection-pool' || x == 'response-messaging' }

--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -20,7 +20,7 @@ node['blueflood']['ingest_servers'].each do |server|
 end
 node.default['repose']['peers'] = repose_peers
 
-file 'var/log/repose/blueflood-ingest.log' do
+file '/var/log/repose/blueflood-ingest.log' do
   user 'root'
   group 'root'
   mode 0o0644

--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -5,8 +5,8 @@ include_recipe 'repose::install'
 
 cookbook_file '/etc/repose/blueflood-ingest.wadl'
 
-if %w(stage prod perf01 perf02 qe01 qe02).any? { |e| e.include?(node.environment) }
-  credentials = Chef::EncryptedDataBagItem.load('blueflood', "repose_#{node.environment}")
+if %w(stage prod perf01 perf02 qe01 qe02).any? { |e| e.include?(node.chef_environment) }
+  credentials = Chef::EncryptedDataBagItem.load('blueflood', "repose_#{node.chef_environment}")
   node.default['repose']['keystone_v2']['username_admin'] = credentials['username']
   node.default['repose']['keystone_v2']['password_admin'] = credentials['password']
 end

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -20,7 +20,7 @@ node['blueflood']['query_servers'].each do |server|
 end
 node.default['repose']['peers'] = repose_peers
 
-file 'var/log/repose/blueflood-query.log' do
+file '/var/log/repose/blueflood-query.log' do
   user 'root'
   group 'root'
   mode 0o0644

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -5,8 +5,8 @@ include_recipe 'repose::install'
 
 cookbook_file '/etc/repose/blueflood-query.wadl'
 
-if %w(stage prod perf01 perf02 qe01 qe02).any? { |e| e.include?(node.environment) }
-  credentials = Chef::EncryptedDataBagItem.load('blueflood', "repose_#{node.environment}")
+if %w(stage prod perf01 perf02 qe01 qe02).any? { |e| e.include?(node.chef_environment) }
+  credentials = Chef::EncryptedDataBagItem.load('blueflood', "repose_#{node.chef_environment}")
   node.default['repose']['keystone_v2']['username_admin'] = credentials['username']
   node.default['repose']['keystone_v2']['password_admin'] = credentials['password']
 end

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -3,7 +3,7 @@ require_relative 'spec_helper'
 
 describe 'metrics-repose' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_OPTS).converge(described_recipe) }
 
   it 'includes the repose::default recipe' do
     expect(chef_run).to include_recipe('repose::default')

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -3,7 +3,7 @@ require_relative 'spec_helper'
 
 describe 'metrics-repose' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe) }
 
   it 'includes the repose::default recipe' do
     expect(chef_run).to include_recipe('repose::default')

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -25,7 +25,7 @@ describe 'metrics-repose' do
   it 'starts a service called repose-valve' do
     expect(chef_run).to start_service('repose-valve')
   end
- 
+
   it 'creates a template /etc/repose/metrics.cfg.xml' do
     expect(chef_run).to create_template('/etc/repose/metrics.cfg.xml')
   end

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -1,16 +1,35 @@
 require 'chefspec'
 require_relative 'spec_helper'
 
-describe 'metrics-repose::default' do
+describe 'metrics-repose' do
   before { stub_resources }
-
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'includes the `repose::default` recipe' do
+  it 'includes the repose::default recipe' do
     expect(chef_run).to include_recipe('repose::default')
   end
 
-  it 'includes the `java::default` recipe' do
-    expect(chef_run).to include_recipe('java::default')
+  it 'creates a template /etc/init/repose-valve.conf' do
+    expect(chef_run).to create_template('/etc/init/repose-valve.conf')
+  end
+  it 'deletes the old init start script at /etc/init.d/repose-valve' do
+    expect(chef_run).to delete_file('/etc/init.d/repose-valve')
+  end
+  it 'creates a symlink to the upstart template' do
+    expect(chef_run).to create_link('/etc/init.d/repose-valve').with(to: '/lib/init/upstart-job')
+  end
+
+  it 'enables a service called repose-valve' do
+    expect(chef_run).to enable_service('repose-valve')
+  end
+  it 'starts a service called repose-valve' do
+    expect(chef_run).to start_service('repose-valve')
+  end
+ 
+  it 'creates a template /etc/repose/metrics.cfg.xml' do
+    expect(chef_run).to create_template('/etc/repose/metrics.cfg.xml')
+  end
+  it 'creates a directory /etc/repose' do
+    expect(chef_run).to create_directory('/etc/repose')
   end
 end

--- a/test/unit/spec/ingest_spec.rb
+++ b/test/unit/spec/ingest_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'metrics-repose::ingest' do
   before { stub_resources }
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+    ChefSpec::SoloRunner.new(UBUNTU_OPTS) do |node|
       node.default['blueflood']['ingest_servers'] = ['127.0.0.1']
     end.converge(described_recipe)
   end

--- a/test/unit/spec/ingest_spec.rb
+++ b/test/unit/spec/ingest_spec.rb
@@ -1,0 +1,23 @@
+require 'chefspec'
+require_relative 'spec_helper'
+
+describe 'metrics-repose::ingest' do
+  before { stub_resources }
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.default['blueflood']['ingest_servers'] = ['127.0.0.1']
+    end.converge(described_recipe)
+  end
+
+
+  it 'include recipe repose::install' do
+    expect(chef_run).to include_recipe('repose::install')
+  end
+
+  it 'create cookbook file /etc/repose/blueflood-ingest.wadl' do
+    expect(chef_run).to create_cookbook_file('/etc/repose/blueflood-ingest.wadl')
+  end
+  it 'create file /var/log/repose/blueflood-ingest.log' do
+    expect(chef_run).to create_file('/var/log/repose/blueflood-ingest.log')
+  end
+end

--- a/test/unit/spec/ingest_spec.rb
+++ b/test/unit/spec/ingest_spec.rb
@@ -9,7 +9,6 @@ describe 'metrics-repose::ingest' do
     end.converge(described_recipe)
   end
 
-
   it 'include recipe repose::install' do
     expect(chef_run).to include_recipe('repose::install')
   end

--- a/test/unit/spec/ingest_spec.rb
+++ b/test/unit/spec/ingest_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'metrics-repose::ingest' do
   before { stub_resources }
   let(:chef_run) do
-    ChefSpec::SoloRunner.new do |node|
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
       node.default['blueflood']['ingest_servers'] = ['127.0.0.1']
     end.converge(described_recipe)
   end

--- a/test/unit/spec/query_spec.rb
+++ b/test/unit/spec/query_spec.rb
@@ -1,0 +1,22 @@
+require 'chefspec'
+require_relative 'spec_helper'
+
+describe 'metrics-repose::query' do
+  before { stub_resources }
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.default['blueflood']['query_servers'] = ['127.0.0.1']
+    end.converge(described_recipe)
+  end
+
+  it 'include recipe repose::install' do
+    expect(chef_run).to include_recipe('repose::install')
+  end
+
+  it 'create cookbook file /etc/repose/blueflood-query.wadl' do
+    expect(chef_run).to create_cookbook_file('/etc/repose/blueflood-query.wadl')
+  end
+  it 'create file /var/log/repose/blueflood-query.log' do
+    expect(chef_run).to create_file('/var/log/repose/blueflood-query.log')
+  end
+end

--- a/test/unit/spec/query_spec.rb
+++ b/test/unit/spec/query_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'metrics-repose::query' do
   before { stub_resources }
   let(:chef_run) do
-    ChefSpec::SoloRunner.new do |node|
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
       node.default['blueflood']['query_servers'] = ['127.0.0.1']
     end.converge(described_recipe)
   end

--- a/test/unit/spec/query_spec.rb
+++ b/test/unit/spec/query_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'metrics-repose::query' do
   before { stub_resources }
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+    ChefSpec::SoloRunner.new(UBUNTU_OPTS) do |node|
       node.default['blueflood']['query_servers'] = ['127.0.0.1']
     end.converge(described_recipe)
   end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -7,14 +7,9 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chef/application'
 
-::LOG_LEVEL = :fatal
 ::UBUNTU_OPTS = {
   platform: 'ubuntu',
   version: '14.04',
-  log_level: ::LOG_LEVEL
-}.freeze
-::CHEFSPEC_OPTS = {
-  log_level: ::LOG_LEVEL
 }.freeze
 
 def stub_resources

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'chef/application'
 
 ::UBUNTU_OPTS = {
   platform: 'ubuntu',
-  version: '14.04',
+  version: '14.04'
 }.freeze
 
 def stub_resources

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -4,7 +4,7 @@
 
 require 'rspec/expectations'
 require 'chefspec'
-require 'berkshelf'
+require 'chefspec/berkshelf'
 require 'chef/application'
 
 ::LOG_LEVEL = :fatal


### PR DESCRIPTION
# Description 
Add a basic set of unit tests to cover 100% of resources.  Fixed two issues found by adding unit tests, an incorrect path was used previously in a file resource.

# How to test
$ chef exec rspec test/unit