### PR TITLE
Add tenant handling to query nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.16
+- Add tenant handling to repose keystone_v2.cfg.xml to require tenant auth for query nodes and tenanted metrics.
+
 # 0.1.15
 - Fix rate limit values set incorrectly in 0.1.12
 

--- a/README.md
+++ b/README.md
@@ -70,5 +70,32 @@ Download it from: https://www.vagrantup.com/downloads.html
 2. Virtual Box
 Download it from: https://www.virtualbox.org/wiki/Downloads
 
+Optionally for OSX, you can use homebrew install to vagrant and virtualbox together. 
+
+- http://brew.sh/index.html
+- http://sourabhbajaj.com/mac-setup/Vagrant/README.html
+
+```
+brew cask install virtualbox
+brew cask install vagrant
+```
+
 ## Kitchen and Travis
 You can run 'kitchen test' or 'kitchen converge [ingest|query]' to test the cookbook.  This cookbook will run some lint checking on TravisCI when pushed to github.
+
+```
+# useful kitchen commands
+kitchen create 		# builds the basic VM
+kitchen converge 	# tests chef convergence
+kitchen verify 		# runs integration tests
+kitchen destroy 	# clean everything up
+kitchen test 		# basically runs through those 4 steps above) - but does a destroy at the end
+kitchen login 		# will log you into the VM in any of the first 4 steps
+
+# useful vagrant commands
+vagrant global-status 			# list VMs info and states
+vagrant ssh <machine_id> 		# ssh to the vm
+vagrant ssh <machine_id> -c "sudo cat /some_file" > some_file # cat a file on the vm to a local file
+vagrant halt <machine_id> 		# stop the vm
+vagrant destroy <machine_id> 	# destroy the vm, but you should preferably use `kitchen destroy` if possible
+```

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.15'
+version '0.1.16'
 
 depends 'apt'
 depends 'java'

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -114,3 +114,10 @@ node.default['repose']['rate_limiting']['limit_groups'] = [
     ]
   }
 ]
+
+node.default['repose']['keystone_v2']['tenant_handling'] = {
+  'validate_tenant' => {
+    'url_extraction_regex' => '/v2.0/([^/]+)/.+'
+  }
+}
+node.default['repose']['keystone_v2']['white_list'] = ['/v2.0/?']


### PR DESCRIPTION
h3. WHAT

Add tenant_handling to repose for query nodes and path /v2/(tenantId)/*

h3. WHY
Currently, any tenants going through repose (all except internal teams) can search, views, and retrieve metrics for any other tenants as long as they have a valid auth token.  This change will confine their query ability to be valid only for their own metrics.

h3.  HOW
set white_list and tenant_handling attributes for recipes/query.rb similar to how recipes/ingest.rb has it.