### PR TITLE
adding ability to set pre-stop and post-start upstart blocks

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,3 +82,6 @@ default['repose']['ip_identity']['cluster_id'] = ['all']
 default['repose']['ip_identity']['quality'] = 0.2
 default['repose']['ip_identity']['white_list_quality'] = 1.0
 default['repose']['ip_identity']['white_list_ip_addresses'] = ['127.0.0.1', '69.20.62.248/29', '10.190.252.12/32', '10.190.252.10/32']
+
+default['repose']['upstart']['pre-stop'] = nil
+default['repose']['upstart']['post-start'] = nil

--- a/templates/default/repose-valve.upstart.erb
+++ b/templates/default/repose-valve.upstart.erb
@@ -6,6 +6,19 @@ console none
 respawn
 respawn limit 5 60
 
+<% if node['repose']['upstart']['pre-stop'] != nil %>
+pre-stop script
+<%= node['repose']['upstart']['pre-stop'] %>
+end script
+<% end %>
+
+<% if node['repose']['upstart']['post-start'] != nil %>
+post-start script
+<%= node['repose']['upstart']['post-start'] %>
+end script
+<% end %>
+
+
 script
     export JAVA_HOME=/usr/lib/jvm/default-java
     export JAVA_BIN=${JAVA_HOME}/bin/java


### PR DESCRIPTION
By setting the following attributes, ```pre-stop``` and ```post-start``` blocks can be added to the upstart script.

```
default['repose']['upstart']['pre-stop']
default['repose']['upstart']['post-start']
```

By default, these values are ```nil``` and no ```pre-stop``` and ```post-start``` blocks are written to the upstart script.