### PR TITLE
reduce Repose conn pool size to Repose default 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.18
+- Change Repose http-conn-pool max to 400
+
 # 0.1.17
 - Adding pre-stop and post-start upstart blocks
 	

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf'
-gem 'rake'
 gem 'chef'
 gem 'chef-sugar'
+gem 'rake'
 
 group :style do
   gem 'foodcritic'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,8 +31,8 @@ default['repose']['services'] = %w(
 default['repose']['http_connection_pool']['chunked_encoding'] = false
 default['repose']['http_connection_pool']['socket_timeout'] = 600_000 # in millis
 default['repose']['http_connection_pool']['connection_timeout'] = 30_000 # in millis
-default['repose']['http_connection_pool']['max_total'] = 16000
-default['repose']['http_connection_pool']['max_per_route'] = 16000
+default['repose']['http_connection_pool']['max_total'] = 400
+default['repose']['http_connection_pool']['max_per_route'] = 400
 
 default['repose']['header_normalization']['cluster_id'] = ['all']
 default['repose']['header_normalization']['uri_regex'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.17'
+version '0.1.18'
 
 if respond_to?(:source_url)
   source_url 'https://github.com/mmi-cookbooks/metrics-repose'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -31,7 +31,7 @@ describe file('/etc/repose/ip-identity.cfg.xml') do
 end
 describe file('/etc/keystone-v2.cfg.xml') do
   it { should be_file }
-  it { should be_mode 644 }
+  it { should be_mode 640 }
 end
 describe file('/etc/validator.cfg.xml') do
   it { should be_file }

--- a/test/integration/ingest/serverspec/default_spec.rb
+++ b/test/integration/ingest/serverspec/default_spec.rb
@@ -70,7 +70,7 @@ end
 
 describe file('/etc/repose/keystone-v2.cfg.xml') do
   it { should be_file }
-  it { should be_mode 644 }
+  it { should be_mode 640 }
   its(:content) { should match %r{uri="https://identity.api.rackspacecloud.com"} }
 end
 

--- a/test/integration/query/serverspec/default_spec.rb
+++ b/test/integration/query/serverspec/default_spec.rb
@@ -71,7 +71,7 @@ end
 
 describe file('/etc/repose/keystone-v2.cfg.xml') do
   it { should be_file }
-  it { should be_mode 644 }
+  it { should be_mode 640 }
   its(:content) { should match %r{uri="https://identity.api.rackspacecloud.com"} }
 end
 

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -12,7 +12,6 @@ require 'chef/application'
   version: '14.04'
 }.freeze
 
-def stub_resources
-end
+def stub_resources; end
 
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
Max connections of 16000 for Repose's http connection pool is too large. Based on what I've been seeing for a few days in prod is that Repose connections to blueflood stays around 100-122. 

Setting the max to the Repose default 400 should be more than enough to accommodate traffic bursts.