### PR TITLE
fix ip-identity whitelists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.20
+- fix ip_identity white_list_ip_addresses to allow for different ingest and query settings and be overridden in environments
+
 # 0.1.19
 - Add GE special rate limit
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,7 +81,6 @@ default['repose']['ip_user']['cluster_id'] = ['all']
 default['repose']['ip_identity']['cluster_id'] = ['all']
 default['repose']['ip_identity']['quality'] = 0.2
 default['repose']['ip_identity']['white_list_quality'] = 1.0
-default['repose']['ip_identity']['white_list_ip_addresses'] = ['127.0.0.1', '69.20.62.248/29', '10.190.252.12/32', '10.190.252.10/32']
 
 default['repose']['upstart']['pre-stop'] = nil
 default['repose']['upstart']['post-start'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,6 +81,8 @@ default['repose']['ip_user']['cluster_id'] = ['all']
 default['repose']['ip_identity']['cluster_id'] = ['all']
 default['repose']['ip_identity']['quality'] = 0.2
 default['repose']['ip_identity']['white_list_quality'] = 1.0
+default['repose']['ingest']['ip_identity']['white_list_ip_addresses'] = ['127.0.0.1']
+default['repose']['query']['ip_identity']['white_list_ip_addresses'] = ['127.0.0.1']
 
 default['repose']['upstart']['pre-stop'] = nil
 default['repose']['upstart']['post-start'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.19'
+version '0.1.20'
 
 if respond_to?(:source_url)
   source_url 'https://github.com/mmi-cookbooks/metrics-repose'

--- a/recipes/ingest.rb
+++ b/recipes/ingest.rb
@@ -129,3 +129,4 @@ node.default['repose']['keystone_v2']['tenant_handling'] = {
   }
 }
 node.default['repose']['keystone_v2']['white_list'] = ['/v2.0/?']
+node.default['repose']['ip_identity']['white_list_ip_addresses'] = node['repose']['ingest']['ip_identity']['white_list_ip_addresses']

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -129,3 +129,4 @@ node.default['repose']['keystone_v2']['tenant_handling'] = {
   }
 }
 node.default['repose']['keystone_v2']['white_list'] = ['/v2.0/?']
+node.default['repose']['ip_identity']['white_list_ip_addresses'] = node['repose']['query']['ip_identity']['white_list_ip_addresses']


### PR DESCRIPTION
# Description
The wrapper didn't properly set different white_lists for ingest and query - only defaulting to one list.  This should set a default of 127.0.0.1 for each type (ingest and query) and be able to be overridden with an environment attribute.