### PR TITLE
Take 2: cors and merge-header cleanup

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,8 +48,6 @@ suites:
     "recipe[metrics-repose::ingest]",
     "recipe[metrics-repose::default]",
     "recipe[repose::filter-slf4j-http-logging]",
-    "recipe[repose::filter-merge-header]",
-    "recipe[repose::filter-cors]",
     "recipe[repose::filter-header-normalization]",
     "recipe[repose::filter-keystone-v2]",
     "recipe[repose::filter-add-header]",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.22
+- add more CORS resp header to merge-header configuration, only install cors and merge-header on query nodes
+
 # 0.1.21
 - add merge-header and cors filters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.1.22
-- add more CORS resp header to merge-header configuration, only install cors and merge-header on query nodes
+- add more CORS resp header to merge-header configuration
+- only install cors and merge-header on query nodes
 
 # 0.1.21
 - add merge-header and cors filters

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,8 +16,6 @@ default['repose']['slf4j_http_logging']['format'] = '<![CDATA[
 
 default['repose']['filters'] = %w(
   slf4j-http-logging
-  merge-header
-  cors
   header-normalization
   add-header
   keystone-v2
@@ -37,7 +35,14 @@ default['repose']['http_connection_pool']['max_total'] = 400
 default['repose']['http_connection_pool']['max_per_route'] = 400
 
 default['repose']['merge_header']['cluster_id'] = ['all']
-default['repose']['merge_header']['response_headers'] = ['Access-Control-Allow-Methods', 'access-control-expose-headers', 'Vary']
+default['repose']['merge_header']['response_headers'] = %w(
+  Access-Control-Allow-Credentials
+  Access-Control-Allow-Origin
+  Access-Control-Allow-Headers
+  Access-Control-Allow-Methods
+  Access-Control-Expose-Headers
+  Vary
+)
 
 default['repose']['cors']['cluster_id'] = ['all']
 default['repose']['cors']['allowed_methods'] = %w(

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ default['repose']['http_connection_pool']['max_total'] = 400
 default['repose']['http_connection_pool']['max_per_route'] = 400
 
 default['repose']['merge_header']['cluster_id'] = ['all']
-default['repose']['merge_header']['response_headers'] = ['Access-Control-Allow-Methods', 'Vary']
+default['repose']['merge_header']['response_headers'] = ['Access-Control-Allow-Methods', 'access-control-expose-headers', 'Vary']
 
 default['repose']['cors']['cluster_id'] = ['all']
 default['repose']['cors']['allowed_methods'] = %w(

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,22 +34,6 @@ default['repose']['http_connection_pool']['connection_timeout'] = 30_000 # in mi
 default['repose']['http_connection_pool']['max_total'] = 400
 default['repose']['http_connection_pool']['max_per_route'] = 400
 
-default['repose']['merge_header']['cluster_id'] = ['all']
-default['repose']['merge_header']['response_headers'] = %w(
-  Access-Control-Allow-Credentials
-  Access-Control-Allow-Origin
-  Access-Control-Allow-Headers
-  Access-Control-Allow-Methods
-  Access-Control-Expose-Headers
-  Vary
-)
-
-default['repose']['cors']['cluster_id'] = ['all']
-default['repose']['cors']['allowed_methods'] = %w(
-  GET
-  POST
-)
-
 default['repose']['header_normalization']['cluster_id'] = ['all']
 default['repose']['header_normalization']['uri_regex'] = nil
 default['repose']['header_normalization']['whitelist'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures metrics-repose'
 long_description 'Installs/Configures repose and Rackspace Metrics configuration for repose'
-version '0.1.21'
+version '0.1.22'
 
 if respond_to?(:source_url)
   source_url 'https://github.com/mmi-cookbooks/metrics-repose'

--- a/recipes/query.rb
+++ b/recipes/query.rb
@@ -47,7 +47,41 @@ node.default['repose']['endpoints'] = [{
   'default' => true
 }]
 
+node.default['repose']['filters'] = %w(
+  slf4j-http-logging
+  merge-header
+  cors
+  header-normalization
+  add-header
+  keystone-v2
+  ip-identity
+  rate-limiting
+  api-validator
+)
+
 node.default['repose']['slf4j_http_logging']['id'] = 'query-repose-http-log'
+
+node.default['repose']['merge_header']['cluster_id'] = ['all']
+node.default['repose']['merge_header']['response_headers'] = %w(
+  Access-Control-Allow-Credentials
+  Access-Control-Allow-Origin
+  Access-Control-Allow-Headers
+  Access-Control-Allow-Methods
+  Access-Control-Expose-Headers
+  Vary
+)
+
+node.default['repose']['cors']['cluster_id'] = ['all']
+node.default['repose']['cors']['allowed_methods'] = %w(
+  GET
+)
+node.default['repose']['cors']['resources'] = [
+  { 'path'            => '/v2.0/.*/views.*',
+    'allowed_methods' => %w(
+      POST
+    ) }
+]
+
 node.default['repose']['keystone_v2']['groups_in_header'] = true
 node.default['repose']['keystone_v2']['uri'] = 'https://identity.api.rackspacecloud.com'
 node.default['repose']['keystone_v2']['cache'] = {

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -13,14 +13,6 @@ describe file('/etc/repose/slf4j-http-logging.cfg.xml') do
   it { should be_file }
   it { should be_mode 644 }
 end
-describe file('/etc/repose/merge-header.cfg.xml') do
-  it { should be_file }
-  it { should be_mode 644 }
-end
-describe file('/etc/repose/cors.cfg.xml') do
-  it { should be_file }
-  it { should be_mode 644 }
-end
 describe file('/etc/repose/container.cfg.xml') do
   it { should be_file }
   it { should be_mode 644 }

--- a/test/integration/ingest/serverspec/default_spec.rb
+++ b/test/integration/ingest/serverspec/default_spec.rb
@@ -17,28 +17,6 @@ describe file('/etc/repose/slf4j-http-logging.cfg.xml') do
   end
 end
 
-describe file('/etc/repose/merge-header.cfg.xml') do
-  it { should be_file }
-  it { should be_mode 644 }
-  its(:content) do
-    should match %r{    <response>
-        <header>Access-Control-Allow-Methods</header>
-        <header>Vary</header>
-    </response>}
-  end
-end
-
-describe file('/etc/repose/cors.cfg.xml') do
-  it { should be_file }
-  it { should be_mode 644 }
-  its(:content) do
-    should match %r{    <allowed-methods>
-        <method>GET</method>
-        <method>POST</method>
-    </allowed-methods>}
-  end
-end
-
 describe file('/etc/repose/header-normalization.cfg.xml') do
   it { should be_file }
   it { should be_mode 644 }
@@ -143,8 +121,6 @@ describe file('/etc/repose/system-model.cfg.xml') do
   its(:content) do
     should match %r{
             <filter name="slf4j-http-logging" />
-            <filter name="merge-header" />
-            <filter name="cors" />
             <filter name="header-normalization" />
             <filter name="add-header" />
             <filter name="keystone-v2" />

--- a/test/integration/query/serverspec/default_spec.rb
+++ b/test/integration/query/serverspec/default_spec.rb
@@ -22,7 +22,11 @@ describe file('/etc/repose/merge-header.cfg.xml') do
   it { should be_mode 644 }
   its(:content) do
     should match %r{    <response>
+        <header>Access-Control-Allow-Credentials</header>
+        <header>Access-Control-Allow-Origin</header>
+        <header>Access-Control-Allow-Headers</header>
         <header>Access-Control-Allow-Methods</header>
+        <header>Access-Control-Expose-Headers</header>
         <header>Vary</header>
     </response>}
   end
@@ -34,7 +38,6 @@ describe file('/etc/repose/cors.cfg.xml') do
   its(:content) do
     should match %r{    <allowed-methods>
         <method>GET</method>
-        <method>POST</method>
     </allowed-methods>}
   end
 end


### PR DESCRIPTION
A few of the changes:
* add more headers to merge-header. I basically add all the headers that Repose could return in response, as documented here: http://www.openrepose.org/versions/8.4.1.0/filters/cors.html#_response_headers_created
* install cors and merge-header filters on Query nodes only. Ingest nodes should not have CORS
* on Query nodes, only /views API allows POST method, the rest should be open for GET